### PR TITLE
set input type to password for the password field

### DIFF
--- a/public/connect.html
+++ b/public/connect.html
@@ -39,7 +39,7 @@
               </div>
               <div class="form-group">
                 <label for="password">Password</label>
-                <input id="password" type="text" ng-model="password" class="form-control form-control-sm"
+                <input id="password" type="password" ng-model="password" class="form-control form-control-sm"
                        ng-enter="connect(host, username, password)">
               </div>
             </div>


### PR DESCRIPTION
The password field on the /public/connect.html page shows the password in clear text in the browser. Changing the HTML input type to password obscures it.