### PR TITLE
Fix play.i18n.langs to LIST rather than a STRING

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -9,7 +9,7 @@ play.crypto.secret="ki:s:[[@=Ag?QI`W2jMwkY:eqvrJ]JqoJyi2axj3ZvOv^/KavOT4ViJSv?6Y
 
 # The application languages
 # ~~~~~
-play.i18n.langs="en"
+play.i18n.langs=["en"]
 
 play.modules.enabled += "controllers.auth.Module"
 play.modules.enabled += "elastic.ElasticModule"


### PR DESCRIPTION
app crashes on startup because `play.i18n.langs has type STRING rather than LIST`