### PR TITLE
Easily create deb/rpm (with systemd unit file)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 name := "cerebro"
 
+maintainer := "Leonardo Menezes <leonardo.menezes@xing.com>"
+
 version := "0.6.5"
 
 scalaVersion := "2.11.8"
@@ -24,4 +26,12 @@ lazy val root = (project in file(".")).
 
 doc in Compile <<= target.map(_ / "none")
 
+enablePlugins(JavaServerAppPackaging)
+enablePlugins(SystemdPlugin)
+
 pipelineStages := Seq(digest, gzip)
+
+serverLoading := Some(ServerLoader.Systemd)
+systemdSuccessExitStatus in Debian += "143"
+systemdSuccessExitStatus in Rpm += "143"
+linuxPackageMappings += packageTemplateMapping(s"/var/lib/${packageName.value}")() withUser((daemonUser in Linux).value) withGroup((daemonGroup in Linux).value)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -8,11 +8,13 @@ basePath = "/"
 # Defaults to RUNNING_PID at the root directory of the app.
 # To avoid creating a PID file set this value to /dev/null
 #pidfile.path = "/var/run/cerebro.pid"
+pidfile.path=/dev/null
 
 # Rest request history max size per user
 rest.history.size = 50 // defaults to 50 if not specified
 
 # Path of local database file
+#data.path: "/var/lib/cerebro/cerebro.db"
 data.path = "./cerebro.db"
 
 # Authentication

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,4 +13,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.0.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.0")
 
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.0-M9")
+
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")


### PR DESCRIPTION
You can now use 'sbt debian:packageBin' and 'sbt rpm:packageBin'
This create a 'cerebro' user
This also add a /var/lib/cerebro dir owned by cerebro (to put the db)

I don't really know how to handle
```
pidfile.path
data.path
```
for now (maintain a systemd.conf ?)