### PR TITLE
fix windows classpath

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
 )
 
 lazy val root = (project in file(".")).
-  enablePlugins(PlayScala, BuildInfoPlugin).
+  enablePlugins(PlayScala, BuildInfoPlugin, LauncherJarPlugin).
   settings(
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "models"


### PR DESCRIPTION
Fix windows classpath ([http://stackoverflow.com/questions/21429234/play-framework-2-stage-task-on-windows-the-input-line-is-too-long](url)). Tested on windows 10. Issue: #102 