### PR TITLE
Show client-node icons

### DIFF
--- a/app/models/commons/NodeRoles.scala
+++ b/app/models/commons/NodeRoles.scala
@@ -3,9 +3,7 @@ package models.commons
 import play.api.libs.json.{JsArray, JsString, JsValue}
 
 case class NodeRoles(master: Boolean, data: Boolean, ingest: Boolean) {
-
-  def client: Boolean = !master && !data && !ingest
-
+  def client: Boolean = !master && !data
 }
 
 object NodeRoles {


### PR DESCRIPTION
Client nodes can also be ingest nodes. In the Nodes list, the client node icon is no longer missing and the toggle filter works as expected for client nodes.