### PR TITLE
Reverting application.conf to have 'changeme' for the play framework …

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,6 +1,6 @@
 # Secret will be used to sign session cookies, CSRF tokens and for other encryption utilities.
 # It is highly recommended to change this value before running cerebro in production.
-secret = "ki:s:[[@=Ag?QI`W2jMwkY:eqvrJ]JqoJyi2axj3ZvOv^/KavOT4ViJSv?6YY4[N"
+secret = "changeme"
 
 # Application base path
 basePath = "/"


### PR DESCRIPTION
…secret, to force users to change it.

I've already observed one scenario where a deployment forgot to change the secret. Switching it back to "changeme" will notify the play framework to fail to run in PROD mode and will ensure there aren't insecure deployments.