### PR TITLE
Fix wrong icon for coordinating nodes

### DIFF
--- a/public/nodes/index.html
+++ b/public/nodes/index.html
@@ -63,7 +63,7 @@
               <i class="fa fa-fw fa-hdd-o" title="data node"></i>
             </div>
             <div ng-show="node.coordinating">
-              <i class="fa fa-fw fa-search" title="coordinating node"></i>
+              <i class="fa fa-fw fa-crosshairs" title="coordinating node"></i>
             </div>
             <div ng-show="node.ingest">
               <i class="fa fa-fw fa-crop" title="ingest node"></i>


### PR DESCRIPTION
In order to have a consistent icon for coordinating nodes between the legend and the nodes' list, I replaced the fa-search icon by the fa-crosshairs one.