### PR TITLE
Add debounce option for the index name filter in the overview template

### DIFF
--- a/public/overview.html
+++ b/public/overview.html
@@ -5,6 +5,7 @@
       <div class="row">
         <div class="col-lg-6 col-sm-6 form-group">
           <input type="text" ng-model="paginator.filter.name" class="form-control form-control-sm"
+                 ng-model-options='{ debounce: 250 }'
                  placeholder="filter indices by name or aliases">
         </div>
         <div class="col-lg-3 col-sm-3 col-xs-6 form-group">


### PR DESCRIPTION
When dealing with a lot of indexes on ES, the index filter input in the overview view is sometimes slow after trying to filter the indexes shown on each key stroke. Adding a small debounce option causes a better filtering experience.