### PR TITLE
Add include_segment_file_sizes flag to stats calls

### DIFF
--- a/app/elastic/HTTPElasticClient.scala
+++ b/app/elastic/HTTPElasticClient.scala
@@ -28,17 +28,18 @@ class HTTPElasticClient @Inject()(client: WSClient) extends ElasticClient {
   }
 
   def nodesStats(stats: Seq[String], target: ElasticServer) = {
-    val path = s"/_nodes/stats/${stats.mkString(",")}?human=true"
+    val includeFileSizes = if (stats.contains("indices")) "&include_segment_file_sizes=true" else ""
+    val path = s"/_nodes/stats/${stats.mkString(",")}?human=true$includeFileSizes"
     execute(path, "GET", None, target)
   }
 
   def indexStats(index: String, target: ElasticServer): Future[ElasticResponse] = {
-    val path = s"/${encoded(index)}/_stats?human=true"
+    val path = s"/${encoded(index)}/_stats?human=true&include_segment_file_sizes=true"
     execute(path, "GET", None, target)
   }
 
   def nodeStats(node: String, target: ElasticServer) = {
-    val path = s"/_nodes/${encoded(node)}/stats?human"
+    val path = s"/_nodes/${encoded(node)}/stats?human&include_segment_file_sizes=true"
     execute(path, "GET", None, target)
   }
 
@@ -122,7 +123,7 @@ class HTTPElasticClient @Inject()(client: WSClient) extends ElasticClient {
     putClusterSettings(allocationSettings("none"), target)
 
   def getShardStats(index: String, target: ElasticServer) = {
-    val path = s"/${encoded(index)}/_stats?level=shards&human=true"
+    val path = s"/${encoded(index)}/_stats?level=shards&human=true&include_segment_file_sizes=true"
     execute(path, "GET", None, target)
   }
 


### PR DESCRIPTION
This flag aggregates the disk use of the different file types used by Lucene.

This structure looks like:

```json
   "file_sizes": {
      "doc": {
        "size": "660b",
        "size_in_bytes": 660,
        "description": "Frequencies"
      },
      "nvm": {
        "size": "578b",
        "size_in_bytes": 578,
        "description": "Norms"
      },
      "fnm": {
        "size": "6.2kb",
        "size_in_bytes": 6436,
        "description": "Fields"
      },
      "pos": {
        "size": "2.6kb",
        "size_in_bytes": 2754,
        "description": "Positions"
      },
      "dvd": {
        "size": "632b",
        "size_in_bytes": 632,
        "description": "DocValues"
      },
      "fdx": {
        "size": "504b",
        "size_in_bytes": 504,
        "description": "Field Index"
      },
      "dii": {
        "size": "207b",
        "size_in_bytes": 207,
        "description": "Points"
      },
      "nvd": {
        "size": "354b",
        "size_in_bytes": 354,
        "description": "Norms"
      },
      "fdt": {
        "size": "2.3kb",
        "size_in_bytes": 2389,
        "description": "Field Data"
      },
      "tim": {
        "size": "5kb",
        "size_in_bytes": 5141,
        "description": "Term Dictionary"
      },
      "dim": {
        "size": "348b",
        "size_in_bytes": 348,
        "description": "Points"
      },
      "tip": {
        "size": "1.4kb",
        "size_in_bytes": 1482,
        "description": "Term Index"
      },
      "dvm": {
        "size": "1.6kb",
        "size_in_bytes": 1721,
        "description": "DocValues"
      }
    }
```