### PR TITLE
Fixing the orderby for index names.

### DIFF
--- a/public/create_index.html
+++ b/public/create_index.html
@@ -28,7 +28,7 @@
           <div class="col-xs-12">
             <div class="form-group">
               <label class="form-label">load settings from existing index</label>
-              <select ng-model="index" ng-options="i as i for i in indices | orderBy:'i'" class="form-control" ng-change="loadIndexMetadata(index)">
+              <select ng-model="index" ng-options="i as i for i in indices | orderBy:i" class="form-control" ng-change="loadIndexMetadata(index)">
               </select>
             </div>
           </div>

--- a/public/snapshot/index.html
+++ b/public/snapshot/index.html
@@ -5,7 +5,7 @@
       <div class="form-inline form-group pull-right">
         <div class="form-group">
           <select class="form-control" ng-model="repository"
-                  ng-options="r for r in repositories| orderBy:'r'">
+                  ng-options="r for r in repositories| orderBy:r">
             <option value="">select repository</option>
           </select>
         </div>
@@ -69,7 +69,7 @@
               <input type="checkbox" ng-model="showSpecialIndices" ng-true-value="true"> show special indices
             </label>
           </label>
-          <select multiple ng-model="form.indices" ng-options="index.name for index in indices | orderBy:'name'"
+          <select multiple ng-model="form.indices" ng-options="index.name for index in indices | orderBy:name"
                   class="form-control" size="13">
           </select>
         </div>


### PR DESCRIPTION
This corrects several Angular `orderBy` clauses which didn't properly sort the lists.