### PR TITLE
Add username formatting option to support OpenLDAP and others

### DIFF
--- a/app/controllers/auth/AuthConfig.scala
+++ b/app/controllers/auth/AuthConfig.scala
@@ -8,4 +8,8 @@ trait AuthConfig {
     config.getString(setting).getOrElse(throw MissingSettingException(setting))
   }
 
+  def getOptionalSetting(setting: String)(implicit config: Configuration) = {
+    config.getString(setting).getOrElse("")
+  }
+
 }

--- a/app/controllers/auth/ldap/LDAPAuthConfig.scala
+++ b/app/controllers/auth/ldap/LDAPAuthConfig.scala
@@ -7,7 +7,8 @@ class LDAPAuthConfig(config: Configuration) extends AuthConfig {
 
   implicit val conf = config
 
-  final val domain = getSetting("user-domain")
+  final val domain = getOptionalSetting("user-domain")
+  final val userformat = getOptionalSetting("user-format")
   final val method = getSetting("method")
   final val url = getSetting("url")
   final val baseDN = getSetting("base-dn")

--- a/app/controllers/auth/ldap/LDAPAuthService.scala
+++ b/app/controllers/auth/ldap/LDAPAuthService.scala
@@ -21,10 +21,15 @@ class LDAPAuthService @Inject()(globalConfig: Configuration) extends AuthService
     env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory")
     env.put(Context.PROVIDER_URL, s"${config.url}/${config.baseDN}")
     env.put(Context.SECURITY_AUTHENTICATION, config.method)
-    if (username.endsWith(s"@${config.domain}")) {
+
+    if (username.contains("@")) {
       env.put(Context.SECURITY_PRINCIPAL, username)
-    } else {
+    } else if (!config.domain.isEmpty()){
       env.put(Context.SECURITY_PRINCIPAL, s"$username@${config.domain}")
+    } else if (!config.userformat.isEmpty()) {
+      env.put(Context.SECURITY_PRINCIPAL, config.userformat.format(username,config.baseDN))
+    } else {
+      throw controllers.auth.MissingSettingException("Must set either user-domain or user-format setting in the configuration")
     }
     env.put(Context.SECURITY_CREDENTIALS, password)
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -29,7 +29,13 @@ auth = {
       #url = "ldap://host:port"
       #base-dn = "ou=active,ou=Employee"
       #method  = "simple"
+      # Usernames in the form of email addresses (containing @) are passed through unchanged
+      # Uncomment and set user-domain to append @user-domain to bare usernames
       #user-domain = "domain.com"
+      # Uncomment and set user-format to format bare usernames
+      # username is passed in first, followed by base-dn
+      # Typical for OpenLDAP
+      #user-format = "uid=%s,%s"
     #}
   # Example of simple username/password authentication
   #type: basic

--- a/public/snapshot/index.html
+++ b/public/snapshot/index.html
@@ -69,7 +69,7 @@
               <input type="checkbox" ng-model="showSpecialIndices" ng-true-value="true"> show special indices
             </label>
           </label>
-          <select multiple="multiple" ng-model="form.indices" ng-options="i.name as i.name for i in indices | orderBy:name"
+          <select multiple="multiple" ng-model="form.indices" ng-options="i.name as i.name for i in indices | orderBy:'name'"
                   class="form-control" size="13">
           </select>
         </div>


### PR DESCRIPTION
While attempting to use LDAP auth with my OpenLDAP server, I ran into #230 as well.

This change-set is somewhat more complicated than it needs to be, in order to attempt support backwards-compatibility. If these changes are acceptable, I'd suggest deprecating user-domain in favor of a user-format = "%s@domain.com" at which point some of the changes can be tidied up.

Note that these changes adjust the behavior of the email type username case such that user@test.com will be passed through unchanged rather than being converted to user@test.com@domain.com; I assume this is preferable to the old behavior.