### PR TITLE
Add username formatting option to support OpenLDAP and others

### DIFF
--- a/app/controllers/auth/ldap/LDAPAuthConfig.scala
+++ b/app/controllers/auth/ldap/LDAPAuthConfig.scala
@@ -8,6 +8,7 @@ class LDAPAuthConfig(config: Configuration) extends AuthConfig {
   implicit val conf = config
 
   final val domain = getSetting("user-domain")
+  final val userformat = getSetting("user-format")
   final val method = getSetting("method")
   final val url = getSetting("url")
   final val baseDN = getSetting("base-dn")

--- a/app/controllers/auth/ldap/LDAPAuthService.scala
+++ b/app/controllers/auth/ldap/LDAPAuthService.scala
@@ -21,11 +21,15 @@ class LDAPAuthService @Inject()(globalConfig: Configuration) extends AuthService
     env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory")
     env.put(Context.PROVIDER_URL, s"${config.url}/${config.baseDN}")
     env.put(Context.SECURITY_AUTHENTICATION, config.method)
-    if (username.endsWith(s"@${config.domain}")) {
+
+    if (username.contains("@")) {
       env.put(Context.SECURITY_PRINCIPAL, username)
-    } else {
+    } else if (!config.domain.isEmpty()){
       env.put(Context.SECURITY_PRINCIPAL, s"$username@${config.domain}")
+    } else {
+      env.put(Context.SECURITY_PRINCIPAL, config.userformat.format(username,config.baseDN))
     }
+    log.debug(s"Logging into LDAP with user ${env.get(Context.SECURITY_PRINCIPAL)}")
     env.put(Context.SECURITY_CREDENTIALS, password)
 
     try {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -28,8 +28,24 @@ auth = {
     #settings: {
       #url = "ldap://host:port"
       #base-dn = "ou=active,ou=Employee"
+      # OpenLDAP might be something like
+      #base-dn = "ou=People,dc=domain,dc=com"
+      # Usually method should be left as simple
+      # Otherwise, set it to the SASL mechanisms to try
       #method  = "simple"
+      # Usernames in the form of email addresses (containing @) are passed through unchanged
+      # Set user-domain to append @user-domain to bare usernames
       #user-domain = "domain.com"
+      # Or leave empty to use user-format formatting
+      #user-domain = ""
+      # user-format executes a string.format() operation where
+      # username is passed in first, followed by base-dn
+      # Leave username unchanged
+      #user-format = "%s"
+      # Like setting user-domain
+      #user-format = "%s@domain.com"
+      # Common for OpenLDAP
+      #user-format = "uid=%s,%s"
     #}
   # Example of simple username/password authentication
   #type: basic


### PR DESCRIPTION
While attempting to use LDAP auth with my OpenLDAP server, I ran into #230 as well. This PR is meant to add more flexible username formatting to support additional LDAP implementations.

This PR supersedes #242 as I discovered I really should have branched first.

I've also simplified the changeset somewhat, at the expense of a new "user-format" config entry being required (if preferred, I'm happy to change it back to the old approach of adding an getOptionalSetting).

I've also added a DEBUG log statement to print the username being used for the login, as well as additional examples and notes in the application.conf.

Note that these changes adjust the behavior of the email type username case such that user@test.com will be passed through unchanged rather than being converted to user@test.com@domain.com; I assume this is preferable to the old behavior.