### PR TITLE
Add docker file for cerebro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM openjdk:8-jre
+
+ENV CEREBRO_VERSION 0.7.3
+RUN cd /opt/ \
+    && wget -O cerebro-${CEREBRO_VERSION}.tgz https://github.com/lmenezes/cerebro/releases/download/v${CEREBRO_VERSION}/cerebro-${CEREBRO_VERSION}.tgz \
+    && tar zxvf cerebro-${CEREBRO_VERSION}.tgz \
+    && rm cerebro-${CEREBRO_VERSION}.tgz \
+    && mkdir cerebro-${CEREBRO_VERSION}/logs \
+    && mv cerebro-${CEREBRO_VERSION} cerebro
+
+WORKDIR /opt/cerebro
+EXPOSE 9000
+CMD ["./bin/cerebro"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ cerebro needs Java 1.8 or newer to run.
 - Run bin/cerebro(or bin/cerebro.bat if on Windows)
 - Access on http://localhost:9000
 
+### Docker image
+
+- Build docker image: `docker build -t cerebro:development .`
+- Run the image: `docker run --rm -it -p 9000:9000 cerebro:development`
+
 ### Configuration
 
 #### HTTP server address and port


### PR DESCRIPTION
Based on the discussion on issue #8 , added the dockerfile from https://github.com/yannart/docker-cerebro 's to this project. 

Let me know if there is anything else that should be added to this PR. I'm sure a lot of people would appreciate automated builds on Docker Hub based on the release of cerebro.