### PR TITLE
Fix Dockerfile not building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
 FROM openjdk:8-jre-alpine
 
-RUN apk --no-cache add bash
-
 ENV CEREBRO_VERSION 0.8.1
-ADD https://github.com/lmenezes/cerebro/releases/download/v${CEREBRO_VERSION}/cerebro-${CEREBRO_VERSION}.tgz /opt/
-RUN tar zxvf /opt/cerebro-${CEREBRO_VERSION}.tgz -C /opt && mv /opt/cerebro-${CEREBRO_VERSION} /opt/cerebro
-RUN mkdir /opt/cerebro/logs
 
-# remove logback file appender
-RUN sed -i '/<appender-ref ref="FILE"\/>/d' /opt/cerebro/conf/logback.xml
+RUN apk add --no-cache bash \
+ && mkdir -p /opt/cerebro/logs \
+ && wget -qO- https://github.com/lmenezes/cerebro/releases/download/v${CEREBRO_VERSION}/cerebro-${CEREBRO_VERSION}.tgz \
+  | tar xzv --strip-components 1 -C /opt/cerebro \
+ && sed -i '/<appender-ref ref="FILE"\/>/d' /opt/cerebro/conf/logback.xml \
+ && addgroup -g 1000 cerebro \
+ && adduser -D -G cerebro -u 1000 cerebro \
+ && chown -R cerebro:cerebro /opt/cerebro
 
 WORKDIR /opt/cerebro
 EXPOSE 9000
-ENTRYPOINT ["./bin/cerebro"]
+USER cerebro
+ENTRYPOINT [ "/opt/cerebro/bin/cerebro" ]


### PR DESCRIPTION
- Squash commands to make smaller image
- Running as cerebro user (1000:1000) instead of root (1000 is default uid/gid in
major distros)

Steps to reproduce build error:
```
$ uname -v
Darwin Kernel Version 17.5.0: Mon Mar  5 22:24:32 PST 2018; root:xnu-4570.51.1~1/RELEASE_X86_64
$ docker version
Client:
 Version:      17.06.0-ce
 API version:  1.30
 Go version:   go1.8.3
 Git commit:   02c1d87
 Built:        Fri Jun 23 21:31:53 2017
 OS/Arch:      darwin/amd64

Server:
 Version:      17.06.0-ce
 API version:  1.30 (minimum version 1.12)
 Go version:   go1.8.3
 Git commit:   02c1d87
 Built:        Fri Jun 23 21:51:55 2017
 OS/Arch:      linux/amd64
 Experimental: true
$ git checkout v0.8.1
$ docker build .
Sending build context to Docker daemon  7.044MB
Step 1/10 : FROM openjdk:8-jre-alpine
 ---> 0d9e1f3f7a1b
Step 2/10 : RUN apk --no-cache add bash
 ---> Using cache
 ---> 5d01db9e72e6
Step 3/10 : ENV CEREBRO_VERSION 0.8.1
 ---> Using cache
 ---> 0d4f02297f63
Step 4/10 : ADD https://github.com/lmenezes/cerebro/releases/download/v${CEREBRO_VERSION}/cerebro-${CEREBRO_VERSION}.tgz /opt/
Downloading [==================================================>]  56.52MB/56.52MB
 ---> Using cache
 ---> 1d27c6a3052b
Step 5/10 : RUN tar zxvf /opt/cerebro-${CEREBRO_VERSION}.tgz -C /opt && mv /opt/cerebro-${CEREBRO_VERSION} /opt/cerebro
 ---> Running in e3acbed69913
tar: can't open '/opt/cerebro-0.8.1.tgz': No such file or directory
The command '/bin/sh -c tar zxvf /opt/cerebro-${CEREBRO_VERSION}.tgz -C /opt && mv /opt/cerebro-${CEREBRO_VERSION} /opt/cerebro' returned a non-zero code: 1
```