### PR TITLE
Sbt configuration for creating rpm and deb packages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,20 @@ name := "cerebro"
 
 maintainer := "Leonardo Menezes <leonardo.menezes@xing.com>"
 
+packageSummary := "Elasticsearch web admin tool"
+
+packageDescription := """cerebro is an open source(MIT License) elasticsearch web admin tool built
+  using Scala, Play Framework, AngularJS and Bootstrap."""
+
 version := "0.8.2"
 
 scalaVersion := "2.12.8"
+
+rpmVendor := "lmenezes"
+
+rpmLicense := Some("MIT")
+
+rpmUrl := Some("http://github.com/lmenezes/cerebro")
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play"                    % "2.7.0",
@@ -22,7 +33,7 @@ libraryDependencies += ws
 libraryDependencies += guice
 
 lazy val root = (project in file(".")).
-  enablePlugins(PlayScala, BuildInfoPlugin, LauncherJarPlugin).
+  enablePlugins(PlayScala, BuildInfoPlugin, LauncherJarPlugin, JDebPackaging, RpmPlugin).
   settings(
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "models"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,3 +16,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.19")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
+
+libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))


### PR DESCRIPTION
Closes #149 

This change allow you to use `rpm:packageBin` and `debian:packageBin` command to generate rpm and deb packages. If this PR gets merged I will include both packages in the next release