### PR TITLE
Added ability to provide credentials in URL

### DIFF
--- a/src/app/components/connect/controller.js
+++ b/src/app/components/connect/controller.js
@@ -27,25 +27,35 @@ angular.module('cerebro').controller('ConnectController', [
       $scope.feedback = undefined;
       $scope.host = host;
       $scope.connecting = true;
-      var success = function(data) {
-        $scope.connecting = false;
-        switch (data.status) {
-          case 200:
-            ConnectDataService.connect(host);
-            $location.path('/overview');
-            break;
-          case 401:
-            $scope.unauthorized = true;
-            break;
-          default:
-            feedback('Unexpected response status: [' + data.status + ']');
+      var parser = document.createElement('a');
+      parser.href = host;
+      if (parser.username && parser.password) {
+        var esHost = parser.protocol + '//' + parser.host;
+        if (parser.port) {
+          esHost = esHost + ':' + parser.port;
         }
-      };
-      var error = function(data) {
-        $scope.connecting = false;
-        AlertService.error('Error connecting to [' + host + ']', data);
-      };
-      ConnectDataService.testConnection(host, success, error);
+        $scope.authorize(esHost, parser.username, parser.password);
+      } else {
+        var success = function(data) {
+          $scope.connecting = false;
+          switch (data.status) {
+            case 200:
+              ConnectDataService.connect(host);
+              $location.path('/overview');
+              break;
+            case 401:
+              $scope.unauthorized = true;
+              break;
+            default:
+              feedback('Unexpected response status: [' + data.status + ']');
+          }
+        };
+        var error = function(data) {
+          $scope.connecting = false;
+          AlertService.error('Error connecting to [' + host + ']', data);
+        };
+        ConnectDataService.testConnection(host, success, error);
+      }
     };
 
     $scope.authorize = function(host, username, pwd) {


### PR DESCRIPTION
Hi @lmenezes 
I'm using [keycloak-gatekeeper](https://github.com/keycloak/keycloak-gatekeeper) to protect elasticsearch instances and scenario when ES responses with HTTP 401 which makes login screen appear doesn't work for me, cause keycloak-gatekeeper redirects to login page and responses with HTTP 200. I've added ability to specify credentials in ES url according to RFC-1738 in a format `<protocol>://<username>:<password>@<host>:<port>`