### PR TITLE
Fixes snapshot index to also replace colons in snapshot names

### DIFF
--- a/public/snapshot/index.html
+++ b/public/snapshot/index.html
@@ -23,10 +23,10 @@
                href="#confirm_dialog">
             </i>
             <i class="fa fa-download normal-action pull-right"
-               data-toggle="collapse" href="#{{snapshot.snapshot.replace('.','_')}}_details">
+               data-toggle="collapse" href="#{{snapshot.snapshot.replace(/(:|\.)/g,'_')}}_details">
             </i>
           </div>
-          <div class="collapse" id="{{snapshot.snapshot.replace('.','_')}}_details">
+          <div class="collapse" id="{{snapshot.snapshot.replace(/(:|\.)/g,'_')}}_details">
             <ng-include src="'./snapshot/restore_snapshot.html'"
                         onload="form = {includeAliases: true, includeGlobalState: true, ignoreUnavailable: true}">
               {{form}}


### PR DESCRIPTION
This project uses Bootstrap 3, Bootstrap 3 uses jQuery for selectors, jQuery selectors [fail on colons and periods, as they are also valid CSS](http://learn.jquery.com/using-jquery-core/faq/how-do-i-select-an-element-by-an-id-that-has-characters-used-in-css-notation/)

Addresses #212 