### PR TITLE
Allow forwarding of proxy/request headers to ES

### DIFF
--- a/app/elastic/HTTPElasticClient.scala
+++ b/app/elastic/HTTPElasticClient.scala
@@ -321,8 +321,11 @@ class HTTPElasticClient @Inject()(client: WSClient) extends ElasticClient {
                            headers: Seq[(String, String)] = Seq()) = {
     val authentication = target.authentication
     val url = s"${target.host.replaceAll("/+$", "")}$uri"
+
+    val mergedHeaders = headers ++ target.forwardHeaders()
+
     val request =
-      authentication.foldLeft(client.url(url).withMethod(method).withHttpHeaders(headers: _*)) {
+      authentication.foldLeft(client.url(url).withMethod(method).withHttpHeaders(mergedHeaders: _*)) {
       case (request, auth) =>
         request.withAuth(auth.username, auth.password, WSAuthScheme.BASIC)
     }

--- a/app/models/CerebroRequest.scala
+++ b/app/models/CerebroRequest.scala
@@ -49,9 +49,11 @@ object CerebroRequest {
     }
 
     val server = hosts.getServer(host) match {
-      case Some(ElasticServer(h, a)) => ElasticServer(h, a.orElse(requestAuth))
+      case Some(ElasticServer(h, a, forward_header)) => ElasticServer(h, a.orElse(requestAuth), forward_header)
       case None => ElasticServer(host, requestAuth)
     }
+
+    server.setForwardHeader(request.headers)
     CerebroRequest(server, body, request.user)
   }
 

--- a/app/models/ElasticServer.scala
+++ b/app/models/ElasticServer.scala
@@ -1,3 +1,18 @@
 package models
 
-case class ElasticServer(host: String, authentication: Option[ESAuth] = None)
+import play.api.mvc.Headers
+
+case class ElasticServer(host: String, authentication: Option[ESAuth] = None, forwardHeadersNames: Seq[String] = Seq.empty) {
+
+  protected var _headers: Seq[(String, String)] = Seq()
+
+  def setForwardHeader(headers : Headers) {
+    for (e <- forwardHeadersNames) {
+      if (headers.hasHeader(e)) {
+        _headers = _headers :+ (e, headers.get(e).orNull)
+      }
+    }
+  }
+
+  def forwardHeaders(): Seq[(String, String)] = _headers
+}

--- a/app/models/Hosts.scala
+++ b/app/models/Hosts.scala
@@ -27,9 +27,10 @@ class HostsImpl @Inject()(config: Configuration) extends Hosts {
       val name = hostConf.getOptional[String]("name").getOrElse(host)
       val username = hostConf.getOptional[String]("auth.username")
       val password = hostConf.getOptional[String]("auth.password")
+      val forward_headers = hostConf.getOptional[Seq[String]](path = "forward_headers").getOrElse(Seq.empty[String])
       (username, password) match {
-        case (Some(username), Some(password)) => (name -> ElasticServer(host, Some(ESAuth(username, password))))
-        case _ => (name -> ElasticServer(host, None))
+        case (Some(username), Some(password)) => (name -> ElasticServer(host, Some(ESAuth(username, password)), forward_headers))
+        case _ => (name -> ElasticServer(host, None, forward_headers))
       }
     }.toMap
     case Failure(_) => Map()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -59,8 +59,9 @@ auth = {
 hosts = [
   #{
   #  host = "http://localhost:9200"
-  #  name = "Some Cluster"
-  #},
+  #  name = "Localhost cluster"
+  #  forward_headers = [ "x-proxy-user", "x-proxy-roles", "X-Forwarded-For" ]
+  #}
   # Example of host with authentication
   #{
   #  host = "http://some-authenticated-host:9200"


### PR DESCRIPTION
This is an implementation for #349 and #295. 

It extends the host configuration with a `forward_headers` field.
It specifies which headers of the original request towards cerebro should be forwarded to the ES instance.