### PR TITLE
Add title with index name in overview table

### DIFF
--- a/public/overview.html
+++ b/public/overview.html
@@ -99,7 +99,7 @@
         <div ng-show="index">
           <div class="dropdown">
               <span class="title normal-action" type="button" id="drop_{{index.name}}" data-toggle="dropdown"
-                    aria-haspopup="true" aria-expanded="false">
+                    aria-haspopup="true" aria-expanded="false" title="{{index.name}}">
                 <i class="fa fa-caret-down pull-right"></i>{{index.name}}
               </span>
             <ul class="dropdown-menu" aria-labelledby="drop_{{index.name}}">


### PR DESCRIPTION
When the index name is too long, it allows to get the title without additionnal click

## Preview
![cerebro-index-title](https://user-images.githubusercontent.com/329467/68272594-9a6d7c80-007d-11ea-8840-38e3154ea3b9.png)