### PR TITLE
allow to select kind of shard allocation in overview

### DIFF
--- a/app/controllers/ClusterOverviewController.scala
+++ b/app/controllers/ClusterOverviewController.scala
@@ -21,7 +21,8 @@ class ClusterOverviewController @Inject()(val authentication: AuthenticationModu
   }
 
   def disableShardAllocation = process { request =>
-    client.disableShardAllocation(request.target).map { response =>
+    val kind = request.get("kind")
+    client.disableShardAllocation(request.target, kind).map { response =>
       CerebroResponse(response.status, response.body)
     }
   }

--- a/app/elastic/ElasticClient.scala
+++ b/app/elastic/ElasticClient.scala
@@ -56,7 +56,7 @@ trait ElasticClient {
 
   def enableShardAllocation(target: ElasticServer): Future[ElasticResponse]
 
-  def disableShardAllocation(target: ElasticServer): Future[ElasticResponse]
+  def disableShardAllocation(target: ElasticServer, kind: String): Future[ElasticResponse]
 
   def getShardStats(index: String, target: ElasticServer): Future[ElasticResponse]
 

--- a/app/elastic/HTTPElasticClient.scala
+++ b/app/elastic/HTTPElasticClient.scala
@@ -124,8 +124,8 @@ class HTTPElasticClient @Inject()(client: WSClient) extends ElasticClient {
   def enableShardAllocation(target: ElasticServer) =
     putClusterSettings(allocationSettings("all"), target)
 
-  def disableShardAllocation(target: ElasticServer) =
-    putClusterSettings(allocationSettings("none"), target)
+  def disableShardAllocation(target: ElasticServer, kind: String) =
+    putClusterSettings(allocationSettings(kind), target)
 
   def getShardStats(index: String, target: ElasticServer) = {
     val path = s"/${encoded(index)}/_stats?level=shards&human=true"

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1411,8 +1411,8 @@ angular.module('cerebro').controller('OverviewController', ['$scope', '$http',
       OverviewDataService.getIndexMapping(index, displayInfo, error);
     };
 
-    $scope.disableShardAllocation = function() {
-      OverviewDataService.disableShardAllocation(success, error);
+    $scope.disableShardAllocation = function(kind) {
+      OverviewDataService.disableShardAllocation(kind, success, error);
     };
 
     $scope.enableShardAllocation = function() {
@@ -1515,8 +1515,8 @@ angular.module('cerebro').factory('OverviewDataService', ['DataService',
       DataService.send('overview/enable_shard_allocation', {}, success, error);
     };
 
-    this.disableShardAllocation = function(success, error) {
-      DataService.send('overview/disable_shard_allocation', {}, success, error);
+    this.disableShardAllocation = function(kind, success, error) {
+      DataService.send('overview/disable_shard_allocation', {kind: kind}, success, error);
     };
 
     this.getShardStats = function(index, node, shard, success, error) {

--- a/public/overview.html
+++ b/public/overview.html
@@ -43,10 +43,25 @@
       <td>
         <div class="row">
           <div class="col-lg-3 col-md-6">
+            <div class="dropdown" ng-show="shardAllocation">
+              <span class="title normal-action" type="button" id="dropallocation" data-toggle="dropdown"
+                                  aria-haspopup="true" aria-expanded="false" title="disable shard allocation">
+                <i class="fa fa-unlock fa-2x table-control"></i>
+              </span>
+              <ul class="dropdown-menu" aria-labelledby="dropallocation">
+                <li ng-click="disableShardAllocation('none')" data-toggle="modal" target="_self">
+                  <a target="_self"><i class="fa fa-fw fa-lock"> </i> none (default)</a>
+                </li>
+                <li ng-click="disableShardAllocation('primaries')" data-toggle="modal" target="_self">
+                  <a target="_self"><i class="fa fa-fw fa-lock"> </i> primaries</a>
+                </li>
+                <li ng-click="disableShardAllocation('new_primaries')" data-toggle="modal" target="_self">
+                  <a target="_self"><i class="fa fa-fw fa-lock"> </i> new primaries</a>
+                </li>
+              </ul>
+            </div>
             <i class="fa fa-lock fa-2x table-control red normal-action" title="enable shard allocation" ng-click="enableShardAllocation()"
                ng-hide="shardAllocation"></i>
-            <i class="fa fa-unlock fa-2x table-control normal-action" title="disable shard allocation" ng-click="disableShardAllocation()"
-               ng-show="shardAllocation"></i>
           </div>
           <div class="col-lg-3 col-md-6">
             <i class="fa fa-expand fa-2x normal-action table-control" ng-hide="expandedView"

--- a/src/app/components/overview/controller.js
+++ b/src/app/components/overview/controller.js
@@ -288,8 +288,8 @@ angular.module('cerebro').controller('OverviewController', ['$scope', '$http',
       OverviewDataService.getIndexMapping(index, displayInfo, error);
     };
 
-    $scope.disableShardAllocation = function() {
-      OverviewDataService.disableShardAllocation(success, error);
+    $scope.disableShardAllocation = function(kind) {
+      OverviewDataService.disableShardAllocation(kind, success, error);
     };
 
     $scope.enableShardAllocation = function() {

--- a/src/app/components/overview/data.js
+++ b/src/app/components/overview/data.js
@@ -44,8 +44,8 @@ angular.module('cerebro').factory('OverviewDataService', ['DataService',
       DataService.send('overview/enable_shard_allocation', {}, success, error);
     };
 
-    this.disableShardAllocation = function(success, error) {
-      DataService.send('overview/disable_shard_allocation', {}, success, error);
+    this.disableShardAllocation = function(kind, success, error) {
+      DataService.send('overview/disable_shard_allocation', {kind: kind}, success, error);
     };
 
     this.getShardStats = function(index, node, shard, success, error) {

--- a/test/controllers/OverviewControllerSpec.scala
+++ b/test/controllers/OverviewControllerSpec.scala
@@ -269,8 +269,8 @@ object OverviewControllerSpec extends MockedServices {
         |}
       """.stripMargin
     )
-    val body = Json.obj("host" -> "somehost")
-    client.disableShardAllocation(ElasticServer(Host("somehost", None))) returns Future.successful(Success(200, expectedResponse))
+    val body = Json.obj("host" -> "somehost", "kind" -> "none")
+    client.disableShardAllocation(ElasticServer(Host("somehost", None)), "none") returns Future.successful(Success(200, expectedResponse))
     val result = route(application, FakeRequest(POST, "/overview/disable_shard_allocation").withBody(body)).get
     ensure(result, 200, expectedResponse)
   }


### PR DESCRIPTION
This PR allows users to select the kind of shard allocation when clicking on the lock symbol in the overview dashboard.

When the Lock Symbol is clicked, a dropdown menu opens where the user can select the kind of shard allocation.

![lock_kind](https://user-images.githubusercontent.com/36934072/72630153-07d93b80-3952-11ea-86e4-87ed6f2e93cd.png)
