### PR TITLE
Sets GET as default method in the REST console

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1677,7 +1677,7 @@ angular.module('cerebro').controller('RestController', ['$scope', '$http',
     $scope.indices = undefined;
     $scope.host = undefined;
 
-    $scope.method = 'POST';
+    $scope.method = 'GET';
     $scope.path = '';
     $scope.options = [];
 


### PR DESCRIPTION
Having POST as default could lead to overwrite something by mistake.

closes #281 