### PR TITLE
Configure cerebro http port using CEREBRO_PORT env var

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -17,6 +17,11 @@ rest.history.size = 50 // defaults to 50 if not specified
 #data.path: "/var/lib/cerebro/cerebro.db"
 data.path = "./cerebro.db"
 
+play {
+  # Cerebro port, by default it's 9000 (play's default)
+  server.http.port = ${?CEREBRO_PORT}
+}
+
 es = {
   gzip = true
 }


### PR DESCRIPTION
This adds the possibility of configuring the port via environment var. 

Related issues: https://github.com/lmenezes/cerebro-docker/pull/5 and https://github.com/lmenezes/cerebro-docker/pull/4