### PR TITLE
Upgrade Play and core libraries

### DIFF
--- a/app/controllers/BaseController.scala
+++ b/app/controllers/BaseController.scala
@@ -5,7 +5,7 @@ import exceptions.MissingRequiredParamException
 import models.{CerebroRequest, CerebroResponse, Hosts}
 import play.api.Logger
 import play.api.libs.json._
-import play.api.mvc.{Controller, InjectedController, Result}
+import play.api.mvc.{InjectedController, Result}
 import services.exception.RequestFailedException
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ packageDescription := """cerebro is an open source(MIT License) elasticsearch we
 
 version := "0.8.5"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.11"
 
 rpmVendor := "lmenezes"
 
@@ -18,10 +18,10 @@ rpmLicense := Some("MIT")
 rpmUrl := Some("http://github.com/lmenezes/cerebro")
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play"                    % "2.7.0",
-  "com.typesafe.play" %% "play-json"               % "2.7.2",
-  "com.typesafe.play" %% "play-slick"              % "4.0.0",
-  "com.typesafe.play" %% "play-slick-evolutions"   % "4.0.0",
+  "com.typesafe.play" %% "play"                    % "2.8.1",
+  "com.typesafe.play" %% "play-json"               % "2.8.1",
+  "com.typesafe.play" %% "play-slick"              % "5.0.0",
+  "com.typesafe.play" %% "play-slick-evolutions"   % "5.0.0",
   "org.xerial"        %  "sqlite-jdbc"             % "3.23.1",
   "org.specs2"        %% "specs2-junit"  % "4.3.4" % "test",
   "org.specs2"        %% "specs2-core"   % "4.3.4" % "test",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-rjs" % "1.0.10")
 
@@ -13,7 +13,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.19")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 


### PR DESCRIPTION
As cerebro is not affected by play 2.8 breaking changes, I'm upgrading play and other core libraries to keep cerebro near the latest versions.