### PR TITLE
Set secret, basePath and data.path from environment variables

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,9 +1,11 @@
 # Secret will be used to sign session cookies, CSRF tokens and for other encryption utilities.
 # It is highly recommended to change this value before running cerebro in production.
 secret = "ki:s:[[@=Ag?QI`W2jMwkY:eqvrJ]JqoJyi2axj3ZvOv^/KavOT4ViJSv?6YY4[N"
+secret = ${?CEREBRO_COOKIE_SECRET}
 
 # Application base path
 basePath = "/"
+basePath = ${?CEREBRO_BASE_PATH}
 
 # Defaults to RUNNING_PID at the root directory of the app.
 # To avoid creating a PID file set this value to /dev/null
@@ -16,6 +18,7 @@ rest.history.size = 50 // defaults to 50 if not specified
 # Path of local database file
 #data.path: "/var/lib/cerebro/cerebro.db"
 data.path = "./cerebro.db"
+data.path = ${?CEREBRO_DATA_PATH}
 
 play {
   # Cerebro port, by default it's 9000 (play's default)


### PR DESCRIPTION
I think this will help when using cerebro in container images or with an environment file in systemd