### PR TITLE
Remove os info of node-stats

### DIFF
--- a/app/controllers/NodesController.scala
+++ b/app/controllers/NodesController.scala
@@ -17,8 +17,8 @@ class NodesController @Inject()(val authentication: AuthenticationModule,
   def index = process { request =>
     Future.sequence(
       Seq(
-        client.nodes(Seq("jvm", "os"), request.target),
-        client.nodesStats(Seq("jvm", "fs", "os", "process"), request.target),
+        client.nodes(Seq("jvm"), request.target),
+        client.nodesStats(Seq("jvm", "fs", "process"), request.target),
         client.catMaster(request.target)
       )
     ).map { responses =>

--- a/app/services/overview/OverviewDataService.scala
+++ b/app/services/overview/OverviewDataService.scala
@@ -15,7 +15,7 @@ class OverviewDataService @Inject()(client: ElasticClient) {
   def overview(target: ElasticServer): Future[JsValue] = {
     val apis = Seq(
       "_cluster/state/master_node,routing_table,blocks",
-      "_nodes/stats/jvm,fs,os,process?human=true",
+      "_nodes/stats/jvm,fs,process?human=true",
       "_stats/docs,store?ignore_unavailable=true",
       "_cluster/settings",
       "_aliases",


### PR DESCRIPTION
There are cases where there is no OS information in the container environment.

```
curl localhost:9000/_nodes/stats/jvm,fs,os,process?human=true
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"Values less than -1 bytes are not supported: -4096b"}],"type":"illegal_argument_exception","reason":"Values less than -1 bytes are not supported: -4096b","suppressed":[{"type":"illegal_state_exception","reason":"Failed to close the XContentBuilder","caused_by":{"type":"i_o_exception","reason":"Unclosed object or array found"}}]},"status":400}
```