### PR TITLE
Menu option to cancel shard relocation

### DIFF
--- a/app/controllers/ClusterOverviewController.scala
+++ b/app/controllers/ClusterOverviewController.scala
@@ -108,4 +108,13 @@ class ClusterOverviewController @Inject()(val authentication: AuthenticationModu
     }
   }
 
+  def cancelShardRelocation = process { request =>
+    val index = request.get("index")
+    val shard = request.getInt("shard")
+    val node = request.get("node")
+    val server = request.target
+    client.cancelShardRelocation(shard, index, node, server).map { response =>
+      CerebroResponse(response.status, response.body)
+    }
+  }
 }

--- a/app/elastic/ElasticClient.scala
+++ b/app/elastic/ElasticClient.scala
@@ -62,6 +62,8 @@ trait ElasticClient {
 
   def relocateShard(shard: Int, index: String, from: String, to: String, target: ElasticServer): Future[ElasticResponse]
 
+  def cancelShardRelocation(shard: Int, index: String, node: String, target: ElasticServer): Future[ElasticResponse]
+
   def getIndexRecovery(index: String, target: ElasticServer): Future[ElasticResponse]
 
   def getClusterMapping(target: ElasticServer): Future[ElasticResponse]

--- a/app/elastic/HTTPElasticClient.scala
+++ b/app/elastic/HTTPElasticClient.scala
@@ -152,6 +152,25 @@ class HTTPElasticClient @Inject()(client: WSClient) extends ElasticClient {
     execute(path, "POST", Some(commands), target, Seq(JsonContentType))
   }
 
+  def cancelShardRelocation(shard: Int, index: String, node: String, target: ElasticServer) = {
+    val path = "/_cluster/reroute"
+    val commands =
+      s"""
+         |{
+         |  "commands": [
+         |    {
+         |      "cancel": {
+         |        "shard": $shard,
+         |        "index": \"$index\",
+         |        "node": \"$node\"
+         |      }
+         |    }
+         |  ]
+         |}
+       """.stripMargin
+    execute(path, "POST", Some(commands), target, Seq(JsonContentType))
+  }
+
   def getIndexRecovery(index: String, target: ElasticServer) = {
     val path = s"/${encoded(index)}/_recovery?active_only=true&human=true"
     execute(path, "GET", None, target)

--- a/conf/routes
+++ b/conf/routes
@@ -23,6 +23,7 @@ POST        /overview/flush_indices                   controllers.ClusterOvervie
 POST        /overview/delete_indices                  controllers.ClusterOverviewController.deleteIndex
 POST        /overview/get_shard_stats                 controllers.ClusterOverviewController.getShardStats
 POST        /overview/relocate_shard                  controllers.ClusterOverviewController.relocateShard
+POST        /overview/cancel_shard_relocation         controllers.ClusterOverviewController.cancelShardRelocation
 
 # Nodes module
 POST        /nodes                                    controllers.NodesController.index

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1441,6 +1441,22 @@ angular.module('cerebro').controller('OverviewController', ['$scope', '$http',
       }
       return false;
     };
+
+    $scope.cancelShardRelocation = function(index, node, shard) {
+      OverviewDataService.cancelShardRelocation(index, node, shard,
+          function(response) {
+            RefreshService.refresh();
+            AlertService.info('Relocation successfully canceled', response);
+          },
+          function(error) {
+            AlertService.error('Error while canceling relocation', error);
+          }
+      );
+    };
+
+    $scope.canCancelShardRelocation = function(shard) {
+	    return shard.state == "INITIALIZING";
+    };
   }]);
 
 angular.module('cerebro').factory('OverviewDataService', ['DataService',
@@ -1500,6 +1516,11 @@ angular.module('cerebro').factory('OverviewDataService', ['DataService',
     this.relocateShard = function(shard, index, from, to, success, error) {
       var data = {shard: shard, index: index, from: from, to: to};
       DataService.send('overview/relocate_shard', data, success, error);
+    };
+
+    this.cancelShardRelocation = function(index, node, shard, success, error) {
+      var data = {index: index, node: node, shard: shard};
+      DataService.send('overview/cancel_shard_relocation', data, success, error);
     };
 
     this.nodeStats = function(node, success, error) {

--- a/public/overview.html
+++ b/public/overview.html
@@ -300,6 +300,9 @@
             <li ng-click="select()" ng-show="isSelected(shard)">
               <a target="_self"><i class="fa fa-fw fa-arrows"> </i> unselect for relocation</a>
             </li>
+            <li ng-click="cancelShardRelocation(shard.index, shard.node, shard.shard)" ng-show="canCancelShardRelocation(shard)">
+              <a target="_self"><i class="fa fa-fw fa-ban"> </i> cancel shard relocation</a>
+            </li>
           </ul>
           </span>
         </span>

--- a/src/app/components/overview/controller.js
+++ b/src/app/components/overview/controller.js
@@ -342,4 +342,16 @@ angular.module('cerebro').controller('OverviewController', ['$scope', '$http',
       }
       return false;
     };
+
+    $scope.cancelShardRelocation = function(index, node, shard) {
+      OverviewDataService.cancelShardRelocation(index, node, shard,
+          function(response) {
+            RefreshService.refresh();
+            AlertService.info('Relocation successfully canceled', response);
+          },
+          function(error) {
+            AlertService.error('Error while canceling relocation', error);
+          }
+      );
+    };
   }]);

--- a/src/app/components/overview/data.js
+++ b/src/app/components/overview/data.js
@@ -57,6 +57,11 @@ angular.module('cerebro').factory('OverviewDataService', ['DataService',
       DataService.send('overview/relocate_shard', data, success, error);
     };
 
+    this.cancelShardRelocation = function(shard, index, from, to, success, error) {
+      var data = {shard: shard, index: index, from: from, to: to};
+      DataService.send('overview/cancel_shard_relocation', data, success, error);
+    };
+
     this.nodeStats = function(node, success, error) {
       DataService.send('commons/get_node_stats', {node: node}, success, error);
     };


### PR DESCRIPTION
This PR adds an option to the overview dashboard to cancel the relocation of individual shards. It adds a menu option to the shard detail menu and only available if the shard is a target shard for relocation.

This PR implements issue https://github.com/lmenezes/cerebro/issues/482 - canceling shard relocations.

![screenshot](https://user-images.githubusercontent.com/121115/118395931-51708e00-b64d-11eb-87f8-c46d1b87d8eb.png)
