### PR TITLE
add default header whitelist config with wildcard host

### DIFF
--- a/app/models/CerebroRequest.scala
+++ b/app/models/CerebroRequest.scala
@@ -48,11 +48,19 @@ object CerebroRequest {
       case _ => None
     }
 
+    // Add default headers if host is set with wildcard. Add default authorization(same with kibana)
+    val defaultHeadersWhitelist: Seq[String] = hosts.getHost("*") match {
+      case Some(Host(_, _, headers)) => headers
+      case None => Seq("Authorization")
+    }
+
     val server = hosts.getHost(hostName) match {
       case Some(host @ Host(h, a, headersWhitelist)) =>
         val headers = headersWhitelist.flatMap(headerName => request.headers.get(headerName).map(headerName -> _))
         ElasticServer(host.copy(authentication = a.orElse(requestAuth)), headers)
-      case None => ElasticServer(Host(hostName, requestAuth))
+      case None =>
+        val headers = defaultHeadersWhitelist.flatMap(headerName => request.headers.get(headerName).map(headerName -> _))
+        ElasticServer(Host(hostName, requestAuth), headers)
     }
 
     CerebroRequest(server, body, request.user)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -68,6 +68,12 @@ auth = {
 
 # A list of known hosts
 hosts = [
+  # Example of wildcard host match for all except specific host name
+  #{
+  #  host = "*"
+  #  headers-whitelist = [ "x-proxy-user", "x-proxy-roles", "X-Forwarded-For", "Authorization" ]
+  #}
+
   #{
   #  host = "http://localhost:9200"
   #  name = "Localhost cluster"


### PR DESCRIPTION
fix https://github.com/lmenezes/cerebro/issues/427

headersWhitelist is configured by host, whitelist would not work if host is not matching within config hosts.

This MR added default headers whitelist with wildcard host config. We can use cerebro for different ES hosts on the fly, so this MR is valuable.