### PR TITLE
Fix #522:  Ldap bind-dn and bind-pwd are required even for non group authentication. 

### DIFF
--- a/app/controllers/auth/ldap/LDAPAuthConfig.scala
+++ b/app/controllers/auth/ldap/LDAPAuthConfig.scala
@@ -21,9 +21,9 @@ class LDAPAuthConfig(config: Configuration) extends AuthConfig {
       LDAPGroupSearchConfig(
         bindDN,
         bindPwd,
-        groupAuthConfig.getOptional[String]("base-dn").getOrElse(baseDN),
+        groupAuthConfig.getOptional[String]("base-dn"),
         getSetting("user-attr")(groupAuthConfig),
-        groupAuthConfig.getOptional[String]("user-attr-template").getOrElse(userTemplate),
+        groupAuthConfig.getOptional[String]("user-attr-template"),
         group
       )
     }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -47,12 +47,11 @@ auth = {
     bind-dn = ${?LDAP_BIND_DN}
     bind-pw = ${?LDAP_BIND_PWD}
     group-search {
-      // If left unset parent's base-dn will be used
+      // OpenLDAP might be something like "ou=People,dc=domain,dc=com"
       base-dn = ${?LDAP_GROUP_BASE_DN}
       // Attribute that represent the user, for example uid or mail
       user-attr = ${?LDAP_USER_ATTR}
       // Define a separate template for user-attr
-      // If left unset parent's user-template will be used
       user-attr-template = ${?LDAP_USER_ATTR_TEMPLATE}
       // Filter that tests membership of the group. If this property is empty then there is no group membership check
       // AD example => memberOf=CN=mygroup,ou=ouofthegroup,DC=domain,DC=com


### PR DESCRIPTION
```
      - AUTH_TYPE=ldap
      - LDAP_METHOD=simple
      - LDAP_URL=ldap://ldap:389
      - LDAP_BASE_DN=DC=example,DC=org
      - LDAP_USER_TEMPLATE=uid=%s,%s
```

Just giving the above configs won't work because even if the `base-dn` and `user-attr-template` in LDAP group search config is always picked up from the parent level if not specified. (https://github.com/lmenezes/cerebro/blob/v0.9.4/app/controllers/auth/ldap/LDAPAuthConfig.scala#L24)
(https://github.com/lmenezes/cerebro/blob/v0.9.4/app/controllers/auth/ldap/LDAPAuthConfig.scala#L26)

this causes the LDAP group search config to Nonempty causing  [line 63](https://github.com/lmenezes/cerebro/blob/v0.9.4/app/controllers/auth/ldap/LDAPAuthService.scala#L63) to execute always instead of [line 64](https://github.com/lmenezes/cerebro/blob/v0.9.4/app/controllers/auth/ldap/LDAPAuthService.scala#L64).

FIX: Removed LDAP config inheriting from the parent level