### PR TITLE
Update Guice for Java 17 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,8 @@ libraryDependencies ++= Seq(
 libraryDependencies += filters
 libraryDependencies += ws
 libraryDependencies += guice
+libraryDependencies += "com.google.inject" % "guice" % "5.0.1"
+libraryDependencies += "com.google.inject.extensions" % "guice-assistedinject" % "5.0.1"
 
 lazy val root = (project in file(".")).
   enablePlugins(PlayScala, BuildInfoPlugin, LauncherJarPlugin, JDebPackaging, RpmPlugin).


### PR DESCRIPTION
Libaray

  com.typesafe.play / play-guice

currently depends on version 4.2.3 of Guice.

Guice 4.x causes 'illegal reflective access' warnings on Java 15
and prevents Cerebro from being usable with Java 16 and and 17 due
to InaccessibleObjectExceptions.

Explicitly include higher version 5.0.1 of the dependencies

  com.google.inject / guice
  com.google.inject.extensions / guice-assistedinject

which work correctly with Java 15 and higher.

Fixes #514.