### PR TITLE
Improve copy to curl

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1715,6 +1715,12 @@ angular.module('cerebro').controller('RestController', ['$scope', '$http',
       if (path.substring(0, 1) !== '/') {
         path = '/' + path;
       }
+	  var host = $scope.host;
+
+	  // cut off trailing slash in hostname to not produce double-slashes
+	  if (host.endsWith('/')) {
+		  host = host.substring(0, host.length - 1);
+	  }
 
       var matchesAPI = function(path, api) {
         return path.indexOf(api) === (path.length - api.length);
@@ -1739,7 +1745,7 @@ angular.module('cerebro').controller('RestController', ['$scope', '$http',
 
       var curl = 'curl';
       curl += ' -H \'Content-type: ' + contentType + '\'';
-      curl += ' -X' + method + ' \'' + $scope.host + path + '\'';
+      curl += ' -X' + method + ' \'' + host + path + '\'';
       if (['POST', 'PUT'].indexOf(method) >= 0) {
         curl += ' -d \'' + body + '\'';
       }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1746,9 +1746,18 @@ angular.module('cerebro').controller('RestController', ['$scope', '$http',
       var curl = 'curl';
       curl += ' -H \'Content-type: ' + contentType + '\'';
       curl += ' -X' + method + ' \'' + host + path + '\'';
+
+	  // add body for POST and PUT
       if (['POST', 'PUT'].indexOf(method) >= 0) {
         curl += ' -d \'' + body + '\'';
       }
+
+	  // GET can have body as well, e.g. the Elasticsearch Query
+      if (['GET'].indexOf(method) >= 0 &&
+		  typeof body !== 'undefined' && body !== '' && body.trim() !== '{}') {
+        curl += ' -d \'' + body + '\'';
+      }
+
       ClipboardService.copy(
           curl,
           function() {


### PR DESCRIPTION
Copying to cURL has two issues:
* if the hostname in the configuration ends with a slash, the resulting cURL has double slashes, which renders it invalid
* HTTP GET can also have a body as part of the request, e.g. when performing Elasticsearch queries

This PR solves both issues.