### PR TITLE
fix hostnames in nav-bar

### DIFF
--- a/app/models/Hosts.scala
+++ b/app/models/Hosts.scala
@@ -36,7 +36,7 @@ class HostsImpl @Inject()(config: Configuration) extends Hosts {
     case Failure(_) => Map()
   }
 
-  def getHostNames() = hosts.keys.toSeq
+  def getHostNames() = hosts.values.map(h => h.name).toSeq
 
   def getHost(name: String) = hosts.get(name)
 


### PR DESCRIPTION
If config file has name, currently cerebro is trying to use names to make some api calls (`/overview`) and fails. 